### PR TITLE
Configure Dependabot for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,100 @@
+version: 2
+updates:
+  # Go backend dependencies
+  - package-ecosystem: "gomod"
+    directory: "/src/backend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "maretol"
+    labels:
+      - "dependencies"
+      - "go"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    groups:
+      aws-sdk:
+        patterns:
+          - "github.com/aws/aws-sdk-go-v2*"
+      minor-updates:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Frontend npm dependencies
+  - package-ecosystem: "npm"
+    directory: "/src/frontend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "maretol"
+    labels:
+      - "dependencies"
+      - "frontend"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    groups:
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react*"
+      next:
+        patterns:
+          - "next"
+          - "eslint-config-next"
+      tailwind:
+        patterns:
+          - "tailwindcss"
+          - "@tailwindcss/*"
+          - "tailwind-*"
+      minor-updates:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Docker base images
+  - package-ecosystem: "docker"
+    directory: "/container"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 3
+    reviewers:
+      - "maretol"
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+
+  # GitHub Actions workflows (future-proofing)
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 3
+    reviewers:
+      - "maretol"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"


### PR DESCRIPTION
## Summary
This PR adds a comprehensive Dependabot configuration to automate dependency updates across the project's Go backend, npm frontend, Docker images, and GitHub Actions workflows.

## Key Changes
- **Go backend dependencies** (`/src/backend`): Weekly updates on Mondays at 09:00 JST with AWS SDK grouped separately
- **Frontend npm dependencies** (`/src/frontend`): Weekly updates with intelligent grouping for React, Next.js, and Tailwind CSS packages
- **Docker base images** (`/container`): Weekly updates for container base images
- **GitHub Actions workflows** (`/`): Weekly updates for GitHub Actions to keep CI/CD workflows current

## Implementation Details
- All updates scheduled for **Monday at 09:00 Asia/Tokyo** for consistent timing
- Commit messages prefixed with `chore(deps)` for clear categorization
- Open PR limit set to 5 for backend/frontend and 3 for Docker/Actions to prevent overwhelming the review queue
- Dependency groups configured to batch related updates together (e.g., React ecosystem, Tailwind utilities)
- Minor and patch updates grouped together to reduce PR noise
- All PRs assigned to `@maretol` for review with appropriate labels for filtering and organization

https://claude.ai/code/session_01AHiRnFqwDR3c5hSfjgnm8g